### PR TITLE
Make freakwan module importable

### DIFF
--- a/freakwan.py
+++ b/freakwan.py
@@ -214,5 +214,6 @@ class FreakWAN:
             time.sleep_ms(urandom.randint(3000,5000)) 
             counter += 1
 
-fw = FreakWAN()
-fw.run()
+if __name__ == "__main__":
+    fw = FreakWAN()
+    fw.run()


### PR DESCRIPTION
I wanted to experiment a bit with BLE but reusing `Scroller` class to manage the display: with this PR we can import from `freakwan` module without starting the WAN (I mean the `run` method of `FreakWAN`).